### PR TITLE
Fix Whitepaper link

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -7,7 +7,7 @@
         <h4 align="center">
             <a href="https://reclaimprotocol.org">Website</a> |
             <a href="https://docs.reclaimprotocol.org/">Documentation</a> |
-            <a href="https://www.reclaimprotocol.org/whitepaper">Whitepaper</a> |
+            <a href="https://drive.google.com/file/d/1Tok4J6mv7PwRCbwxVNhv4alS82sQJI4E/view?usp=sharing">Whitepaper</a> |
             <a href="https://www.reclaimprotocol.org/ecosystem/">Ecosystem</a> |
             <a href="https://t.me/protocolreclaim">Community</a>
         </h4>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Update Whitepaper link in `profile/README.md` to a Google Drive URL.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f9e0afeeaf4b01807732c26ea2a47a0a254b182. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Replaced the outdated Whitepaper link with a Google Drive URL, improving direct access to the document from the header.
- Chores
  - Standardized formatting by adding a trailing newline to the file; no functional impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->